### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NO MUSIC, NO BUILD. Enjoy your compile time.
 
 ```
 $ mkdir ~/bin  # if not exists
-$ https://raw.githubusercontent.com/illusori/bash-itunes/master/itunes > ~/bin/itunes && chmod 0755 !#:3
+$ curl https://raw.githubusercontent.com/illusori/bash-itunes/master/itunes > ~/bin/itunes && chmod 0755 !#:3
 ```
 
  3. In your ~/.sbt/plugins/build.sbt


### PR DESCRIPTION
`curl` is deleted in a9ff1ce39cf0cd289b1b381cdcf4a1f54e40b668.
It seems to be typo. I fixed it.